### PR TITLE
add interval sending feature to send_signal

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ client.appliances
 
 # send signal
 client.send_signal(<signal id>)
+
+# send a signal at intervals
+#   [OPTIONAL]
+#   interval: How long do you want to wait to send next signal?(millisec)
+#   times: How many times do you want to send signals?
+client.send_signal(<signal id>, interval: 500, times: 10)
 ```
 
 ## CLI Usage

--- a/lib/nature_remo/client.rb
+++ b/lib/nature_remo/client.rb
@@ -34,11 +34,16 @@ module NatureRemo
       end
     end
 
-    def send_signal(signal)
-      @client.post do |req|
-        req.url "/1/signals/#{signal}/send"
-        req.body = { name: signal.to_s }
+    def send_signal(signal, interval: 0, times: 1)
+      results = []
+      times.times do |time|
+        sleep(interval.to_f / 1000) if time != 0
+        results << @client.post do |req|
+          req.url "/1/signals/#{signal}/send"
+          req.body = { name: signal.to_s }
+        end
       end
+      results
     end
 
     def aircon_setting(appliance, temp = nil, mode = nil, volume = nil)


### PR DESCRIPTION
# I Want To Do This
```
client.send_signal(signal_id, interval: 1000, times: 2)
# ... wait 2 seconds ...
# => [#<Faraday::Response:, #<Faraday::Response:]
```

# My Use Case
My Audio is controlled my Nature Remo.
I wanna send volume down/up ordering to it at intervals.

Like bellow.

"OK Google, increase volume by 10 increment."
"OK Google, decrease volume by 10 decrement."