### PR TITLE
Support when multiple devices are found

### DIFF
--- a/lib/nature_remo/client.rb
+++ b/lib/nature_remo/client.rb
@@ -75,8 +75,12 @@ module NatureRemo
       end
     end
 
+    def remo
+      JSON.parse(devices.body).find { |device| device['firmware_version'].match(/Remo\/\d+\.\d+\.\d+-[a-z0-9]+/) }
+    end
+
     def events
-      JSON.parse(devices.body)[0]['newest_events']
+      remo['newest_events']
     end
 
     def get_temp

--- a/test/nature_remo/client_test.rb
+++ b/test/nature_remo/client_test.rb
@@ -8,7 +8,7 @@ class ClientTest < Minitest::Test
     WebMock.stub_request(:get, "https://api.nature.global/1/devices").
       to_return(
         status: 200,
-        body: "[{\"newest_events\":{\"hu\":{\"val\":50,\"created_at\":\"dummy\"},\"il\":{\"val\":57.2,\"created_at\":\"dummy\"},\"te\":{\"val\":21.2,\"created_at\":\"dummy\"}}}]"
+        body: "[{\"firmware_version\":\"Remo/1.0.69-gbbcc0de\",\"newest_events\":{\"hu\":{\"val\":50,\"created_at\":\"dummy\"},\"il\":{\"val\":57.2,\"created_at\":\"dummy\"},\"te\":{\"val\":21.2,\"created_at\":\"dummy\"}}}]"
       )
   end
 


### PR DESCRIPTION
## 事象
`get_temp`や`get_humi`、`get_illu`でエラーが発生しました。
```bash
NoMethodError (undefined method `[]' for nil:NilClass)
```

## 原因
Nature RemoとNature Remo E liteを所持しているのですが、`events`メソッドの以下のコードだと
```ruby
JSON.parse(devices.body)[0]
```
Nature Remo E liteの方を見に行ってしまうのでエラーになってしまいました。

## 解決方法
Nature Remoの方を探すロジックを追加しました。  
Remoかどうかはfirmware_versionで判別することにしました。